### PR TITLE
Explicitly disallow some characters forbidden by the RFC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ repository = "https://github.com/jstasiak/sectok"
 
 [dependencies]
 percent-encoding = "2.*"
+regex = "1"
+lazy_static = "1.4"


### PR DESCRIPTION
They are permitted by percent encoding (and we do encode in a
non-verbatim, percent-encoded form) but to follow the RFC strictly we
can't accept them verbatim in the input when decoding.